### PR TITLE
Worker: add shutdown and process exit callbacks

### DIFF
--- a/src/RavenTools/GridManager/SQSQueue.php
+++ b/src/RavenTools/GridManager/SQSQueue.php
@@ -21,7 +21,7 @@ class SQSQueue implements \RavenTools\GridManager\QueueInterface {
 		if(array_key_exists("sqs_client",$params)) {
 			$this->sqs_client = $params['sqs_client'];
 		} else {
-			throw new Exception("sqs_client required");
+			throw new \Exception("sqs_client required");
 		}
 
 		if(array_key_exists("queue_name",$params)) {
@@ -30,7 +30,7 @@ class SQSQueue implements \RavenTools\GridManager\QueueInterface {
 									"QueueName"=>$this->queue_name
 								))->get("QueueUrl");
 		} else {
-			throw new Exception("queue_name required");
+			throw new \Exception("queue_name required");
 		}
 
 		if(array_key_exists("timeout",$params)) {

--- a/src/RavenTools/GridManager/Worker.php
+++ b/src/RavenTools/GridManager/Worker.php
@@ -52,7 +52,7 @@ class Worker {
 		if(array_key_exists("shutdown_callback",$params)) {
 			$this->setShutdownCallback($params['shutdown_callback']);
 		} else {
-			$this->setShutdownCallback(function() { });
+			$this->setShutdownCallback(function() { exit(111); });
 		}
 
 		if(array_key_exists("shutdown_timeout",$params)) {
@@ -62,7 +62,7 @@ class Worker {
 		if(array_key_exists("process_exit_callback",$params)) {
 			$this->setProcessExitCallback($params['process_exit_callback']);
 		} else {
-			$this->setProcessExitCallback(function() { });
+			$this->setProcessExitCallback(function() { exit(); });
 		}
 
 		if(array_key_exists("process_timeout",$params)) {

--- a/src/RavenTools/GridManager/Worker.php
+++ b/src/RavenTools/GridManager/Worker.php
@@ -4,12 +4,26 @@ namespace RavenTools\GridManager;
 
 class Worker {
 
+	protected $num_to_process = 1;
+
 	protected $dequeue_callback = null;
 	protected $work_item_callbacks = array();
 	protected $queue_callback = null;
+	protected $shutdown_callback = null;
+	protected $shutdown_timeout = "5 minutes";
+	protected $process_timeout = "5 minutes";
+
+	protected $start_ts = null;
+	protected $last_item_ts = null;
+
+	protected $running = null;
 
 	public function __construct(Array $params) {
+
 		$this->validateAndSetParams($params);
+
+		$this->start_ts = time();
+		$this->last_item_ts = time();
 	}
 
 	/**
@@ -35,6 +49,44 @@ class Worker {
 			$this->setQueueCallback($params['queue_callback']);
 		}
 
+		if(array_key_exists("shutdown_callback",$params)) {
+			$this->setShutdownCallback($params['shutdown_callback']);
+		} else {
+			$this->setShutdownCallback(function() { });
+		}
+
+		if(array_key_exists("shutdown_timeout",$params)) {
+			$this->setShutdownTimeout($params['shutdown_timeout']);
+		}
+
+		if(array_key_exists("process_timeout",$params)) {
+			$this->setProcessTimeout($params['process_timeout']);
+		}
+
+		if(array_key_exists("num_to_process",$params)) {
+			$this->num_to_process = $this->setNumToProcess($params['num_to_process']);
+		}
+	}
+
+	/**
+	 * sets maximum number of jobs to process before exiting
+	 */
+	public function setNumToProcess($num) {
+		$this->num_to_process = $num;
+	}
+
+	/**
+	 * sets the shutdown timeout (process stops)
+	 */
+	public function setShutdownTimeout($shutdown_timeout) {
+		$this->shutdown_timeout = strtotime($shutdown_timeout) - time();
+	}
+
+	/**
+	 * sets the process timeout (process stops and restarts)
+	 */
+	public function setProcessTimeout($process_timeout) {
+		$this->process_timeout = strtotime($process_timeout) - time();
 	}
 
 	/**
@@ -76,6 +128,17 @@ class Worker {
 	}
 
 	/**
+	 * sets a callback to run when the worker has been idle too long
+	 */
+	public function setShutdownCallback($callback) {
+		if(is_callable($callback)) {
+			$this->shutdown_callback = $callback;
+		} else {
+			throw new \Exception("callable argument required");
+		}
+	}
+
+	/**
 	 * runs the output job
 	 * - dequeues one or more output items
 	 * - runs output item through output item callback chain
@@ -90,27 +153,53 @@ class Worker {
 				"items" => 0
 				);
 
-		$cb = $this->dequeue_callback;
-		$data = call_user_func($cb);
+		$this->running = true;
+		$processed = 0;
 
-		$output_item_buffer = array();
+		while($this->running) {
 
-		if($data !== false) {
-			foreach($data as $work_item) {
+			$data = call_user_func($this->dequeue_callback);
 
-				foreach($this->work_item_callbacks as $cb) {
-					$work_item = call_user_func($cb,$work_item);
+			$output_item_buffer = array();
+
+			if($data !== false) {
+				$this->last_item_ts = time();
+
+				foreach($data as $work_item) {
+
+					foreach($this->work_item_callbacks as $cb) {
+						$work_item = call_user_func($cb,$work_item);
+					}
+
+					$output_item_buffer[] = $work_item;
 				}
 
-				$output_item_buffer[] = $work_item;
-			}
+				if(call_user_func($this->queue_callback,$output_item_buffer) === true) {
+					$response['success']++;
+					$response['items'] += count($output_item_buffer);
+				} else {
+					$response['failure']++;
+				}
 
-			$cb = $this->queue_callback;
-			if(call_user_func($cb,$output_item_buffer) === true) {
-				$response['success'] = 1;
-				$response['items'] += count($output_item_buffer);
+				if(++$processed >= $this->num_to_process) {
+					$this->running = false;
+				} elseif($response['failure'] > $response['success']) {
+					sleep(1);
+				} elseif($response['failure'] == 0 && $response['success'] == 0) {
+					sleep(1);
+				}
 			} else {
-				$response['failure'] = 1;
+
+				if($this->last_item_ts < (time() - $this->process_timeout)) {
+					$this->running = false;
+				}
+
+				if($this->last_item_ts < (time() - $this->shutdown_timeout)) {
+					$this->running = false;
+					call_user_func($this->shutdown_callback);
+				}
+
+				usleep(1000);
 			}
 		}
 

--- a/templates/src/attributes_default.rb.erb
+++ b/templates/src/attributes_default.rb.erb
@@ -4,5 +4,7 @@ default[:<%=params[:cookbook_name]%>][:deploy][:user] = "nobody"
 default[:<%=params[:cookbook_name]%>][:deploy][:branch] = "master"
 
 # worker parameters
+default[:<%=params[:cookbook_name]%>][:worker][:run] = false
 default[:<%=params[:cookbook_name]%>][:worker][:numprocs] = 1
+default[:<%=params[:cookbook_name]%>][:worker][:exitcodes] = [111]
 default[:<%=params[:cookbook_name]%>][:worker][:user] = default[:<%=params[:cookbook_name]%>][:deploy][:user]

--- a/templates/src/recipes_default.rb.erb
+++ b/templates/src/recipes_default.rb.erb
@@ -23,6 +23,7 @@ raven_supervisor_program "<%=params[:program_name]%>" do
 	command "php cli.php worker"
 	numprocs node[:<%=params[:cookbook_name]%>][:worker][:numprocs]
 	user node[:<%=params[:cookbook_name]%>][:worker][:user]
+	exitcodes node[:<%=params[:cookbook_name]%>][:worker][:exitcodes]
 
 	notifies :restart, "service[supervisord]", :delayed
 end

--- a/tests/RavenTools/GridManager/WorkerTest.php
+++ b/tests/RavenTools/GridManager/WorkerTest.php
@@ -30,7 +30,8 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
 			},
 			'queue_callback' => function($work_item) {
 				return true;
-			}
+			},
+			'shutdown_timeout' => '60 seconds'
 		));
     }
 
@@ -45,6 +46,8 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
 	public function testRun() 
 	{
 		$response = $this->object->run();
+
+//		print_r($response);
 
 		$this->assertArrayHasKey("success",$response);
 		$this->assertEquals(1,$response['success']);
@@ -164,5 +167,24 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1,$response['failure']);
         $this->assertArrayHasKey("items",$response);
         $this->assertEquals(0,$response['items']);
+	}
+
+	public function testSetShutdownCallback() { 
+
+		$this->object->setNumToProcess(1);
+		$this->object->setShutdownTimeout("1 second");
+
+		$this->object->setDequeueCallback(function() {
+			return false;
+		});
+
+		$shutdown = null;
+		$this->object->setShutdownCallback(function() use (&$shutdown) {
+			$shutdown = "shut it down";
+		});
+
+		$response = $this->object->run();
+
+		$this->assertEquals("shut it down",$shutdown);
 	}
 }

--- a/tests/RavenTools/GridManager/WorkerTest.php
+++ b/tests/RavenTools/GridManager/WorkerTest.php
@@ -31,6 +31,8 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
 			'queue_callback' => function($work_item) {
 				return true;
 			},
+			'process_exit_callback' => function() { },
+			'shutdown_callback' => function() { },
 			'shutdown_timeout' => '60 seconds'
 		));
     }

--- a/tests/RavenTools/GridManager/WorkerTest.php
+++ b/tests/RavenTools/GridManager/WorkerTest.php
@@ -180,11 +180,49 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
 
 		$shutdown = null;
 		$this->object->setShutdownCallback(function() use (&$shutdown) {
-			$shutdown = "shut it down";
+			$shutdown = "shutting down";
 		});
 
+		// test shutdown timeout and callback
 		$response = $this->object->run();
+		$this->assertEquals("shutting down",$shutdown);
+	}
 
-		$this->assertEquals("shut it down",$shutdown);
+	public function testSetProcessExitCallback() {
+
+		$num_to_process = 10;
+
+		$this->object->setNumToProcess($num_to_process);
+		$this->object->setProcessTimeout("1 seconds");
+
+		$this->object->setDequeueCallback(function() {
+			return array("item");
+		});
+
+		$process_exit = null;
+		$this->object->setProcessExitCallback(function() use (&$process_exit) {
+			$process_exit = "exiting due to processing limit";
+		});
+
+		// test num_to_process limit
+		$response = $this->object->run();
+		$this->assertEquals($num_to_process,$response['success']);
+		$this->assertEquals($num_to_process,$response['items']);
+		$this->assertEquals("exiting due to processing limit",$process_exit);
+
+		$this->object->setDequeueCallback(function() {
+			return false;
+		});
+
+		$process_exit = null;
+		$this->object->setProcessExitCallback(function() use (&$process_exit) {
+			$process_exit = "exiting due to process timeout";
+		});
+
+		// test process timeout
+		$response = $this->object->run();
+		$this->assertEquals(0,$response['success']);
+		$this->assertEquals(0,$response['items']);
+		$this->assertEquals("exiting due to process timeout",$process_exit);
 	}
 }

--- a/tests/RavenTools/GridManager/WorkerTest.php
+++ b/tests/RavenTools/GridManager/WorkerTest.php
@@ -47,8 +47,6 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
 	{
 		$response = $this->object->run();
 
-//		print_r($response);
-
 		$this->assertArrayHasKey("success",$response);
 		$this->assertEquals(1,$response['success']);
 		$this->assertArrayHasKey("failure",$response);


### PR DESCRIPTION
Adds callbacks to support autoscaling:
- process exit callback that is called whenever a worker processes the max amount of items or has an idle timeout.
- shutdown callback that's called after an idle period.  used to shut down server instance
