### PR TITLE
Worker: remove redundant process timeout

### DIFF
--- a/src/RavenTools/GridManager/Worker.php
+++ b/src/RavenTools/GridManager/Worker.php
@@ -11,7 +11,7 @@ class Worker {
 	protected $queue_callback = null;
 	protected $shutdown_callback = null;
 	protected $shutdown_timeout = "5 minutes";
-	protected $process_timeout = "5 minutes";
+	protected $process_exit_callback = null;
 
 	protected $start_ts = null;
 	protected $last_item_ts = null;
@@ -65,10 +65,6 @@ class Worker {
 			$this->setProcessExitCallback(function() { exit(); });
 		}
 
-		if(array_key_exists("process_timeout",$params)) {
-			$this->setProcessTimeout($params['process_timeout']);
-		}
-
 		if(array_key_exists("num_to_process",$params)) {
 			$this->num_to_process = $this->setNumToProcess($params['num_to_process']);
 		}
@@ -86,13 +82,6 @@ class Worker {
 	 */
 	public function setShutdownTimeout($shutdown_timeout) {
 		$this->shutdown_timeout = strtotime($shutdown_timeout) - time();
-	}
-
-	/**
-	 * sets the process timeout (process stops and restarts)
-	 */
-	public function setProcessTimeout($process_timeout) {
-		$this->process_timeout = strtotime($process_timeout) - time();
 	}
 
 	/**
@@ -207,11 +196,6 @@ class Worker {
 					sleep(1);
 				}
 			} else {
-
-				if($this->last_item_ts < (time() - $this->process_timeout)) {
-					$this->running = false;
-					call_user_func($this->process_exit_callback);
-				}
 
 				if($this->last_item_ts < (time() - $this->shutdown_timeout)) {
 					$this->running = false;

--- a/tests/RavenTools/GridManager/WorkerTest.php
+++ b/tests/RavenTools/GridManager/WorkerTest.php
@@ -193,7 +193,6 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
 		$num_to_process = 10;
 
 		$this->object->setNumToProcess($num_to_process);
-		$this->object->setProcessTimeout("1 seconds");
 
 		$this->object->setDequeueCallback(function() {
 			return array("item");
@@ -209,20 +208,5 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals($num_to_process,$response['success']);
 		$this->assertEquals($num_to_process,$response['items']);
 		$this->assertEquals("exiting due to processing limit",$process_exit);
-
-		$this->object->setDequeueCallback(function() {
-			return false;
-		});
-
-		$process_exit = null;
-		$this->object->setProcessExitCallback(function() use (&$process_exit) {
-			$process_exit = "exiting due to process timeout";
-		});
-
-		// test process timeout
-		$response = $this->object->run();
-		$this->assertEquals(0,$response['success']);
-		$this->assertEquals(0,$response['items']);
-		$this->assertEquals("exiting due to process timeout",$process_exit);
 	}
 }


### PR DESCRIPTION
Thinking about this some more, the process timeout is redundant so I'm removing it.
