### PR TITLE
Breaking Change: switch metrics to 3rd party client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
             "email": "phil@raventools.com"
         }
     ],
-    "require": {},
+    "require": {
+        "domnikl/statsd": "^2.2"
+    },
     "require-dev":{
         "mockery/mockery":"0.9.4"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,57 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bb8143a0cca288be3a2f108772e07264",
-    "packages": [],
+    "hash": "1959ad1a1885beb3a9788e5b5eb4364d",
+    "content-hash": "83780b76498665ecc7c33ee6549917cf",
+    "packages": [
+        {
+            "name": "domnikl/statsd",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/domnikl/statsd-php.git",
+                "reference": "6e869109067777dcea56c88759c0e9df7f47c843"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/domnikl/statsd-php/zipball/6e869109067777dcea56c88759c0e9df7f47c843",
+                "reference": "6e869109067777dcea56c88759c0e9df7f47c843",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">= 4.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Domnikl\\Statsd\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dominik Liebler",
+                    "email": "liebler.dominik@gmail.com"
+                }
+            ],
+            "description": "a PHP client for statsd",
+            "homepage": "https://domnikl.github.com/statsd-php",
+            "keywords": [
+                "Metrics",
+                "monitoring",
+                "statistics",
+                "statsd",
+                "udp"
+            ],
+            "time": "2015-10-29 09:44:21"
+        }
+    ],
     "packages-dev": [
         {
             "name": "hamcrest/hamcrest-php",

--- a/src/RavenTools/GridManager/Metrics.php
+++ b/src/RavenTools/GridManager/Metrics.php
@@ -2,23 +2,46 @@
 
 namespace RavenTools\GridManager;
 
+use \Domnikl\Statsd\Client as StatsD;
+use \Domnikl\Statsd\Connection\UdpSocket;
+
 class Metrics {
 
-	private $prefix = null;
+	private $client = null;
 
-	public function __construct($prefix) {
-		$this->prefix = $prefix;
-	}
+	public function __construct($params) {
 
-	private function key($suffix) {
-		return sprintf("%s.%s",$this->prefix,$suffix);
+		if(array_key_exists('prefix',$params) && !empty($params['prefix'])) {
+			$prefix = $params['prefix'];
+		} else {
+			throw new \Exception("prefix parameter required");
+		}
+
+		$host = "127.0.0.1";
+		if(array_key_exists('host',$params) && !empty($params['host'])) {
+			$host = $params['host'];
+		}
+
+		$port = 8125;
+		if(array_key_exists('port',$params) && !empty($params['port'])) {
+			$port = (int)$params['port'];
+		}
+
+		if(array_key_exists('client',$params) && !empty($params['client'])) {
+			$this->client = $params['client'];
+		} else {
+			$this->client = new StatsD(
+				new UdpSocket($host,$port),
+				$prefix
+			);
+		}
 	}
 
 	public function increment($suffix,$sample=1,$value=1) {
-		\StatsD::increment($this->key($suffix),$sample,$value);
+		$this->client->count($suffix,$value,$sample);
 	}
 
 	public function gauge($suffix,$value) {
-		\StatsD::gauge($this->key($suffix),$value);
+		$this->client->gauge($suffix,$value);
 	}
 }


### PR DESCRIPTION
Currently we rely on `StatsD` being included in the global namespace for the `Metrics` class to use it.  It happens to work in the single current application using this library because `StatsD` is pulled in with RavenApp, but won't work going forward.  This adds a 3rd party StatsD client and switches `Metrics` over to use it.  This will bump the version and be tagged as v0.2.0 when merged.
