### PR TITLE
Bug: add default poll timeout

### DIFF
--- a/src/RavenTools/GridManager/SQSQueue.php
+++ b/src/RavenTools/GridManager/SQSQueue.php
@@ -7,7 +7,7 @@ class SQSQueue implements \RavenTools\GridManager\QueueInterface {
 	protected $sqs_client = null;
 	protected $queue_name = null;
 	protected $queue_url = null;
-	protected $timeout = null;
+	protected $timeout = 1;
 
 	public function __construct(Array $params) {
 		$this->validateAndSetParams($params);


### PR DESCRIPTION
If a timeout isn't set when initializing, an exception is thrown due to a missing timeout parameter.   This sets a default `receive()` poll timeout of 1 second.
