### PR TITLE
Bug: fix work item callback init

### DIFF
--- a/src/RavenTools/GridManager/Worker.php
+++ b/src/RavenTools/GridManager/Worker.php
@@ -36,12 +36,14 @@ class Worker {
 			$this->setDequeueCallback($params['dequeue_callback']);
 		}
 
-		if(array_key_exists("work_item_callback",$params) && is_callable($params['work_item_callback'])) {
+		if(array_key_exists("work_item_callback",$params)) {
 			if(is_callable($params['work_item_callback'])) {
 				$this->addWorkItemCallback($params['work_item_callback']);
 			} elseif(is_array($params['work_item_callback'])) {
 				foreach($params['work_item_callback'] as $c) {
-					$this->addWorkItemCallback($c);
+					if(is_callable($c)) {
+						$this->addWorkItemCallback($c);
+					}
 				}
 			}
 		}
@@ -110,6 +112,10 @@ class Worker {
 		} else {
 			throw new \Exception("callable argument required");
 		}
+	}
+
+	public function getWorkItemCallbacks() {
+		return $this->work_item_callbacks;
 	}
 
 	/**

--- a/tests/RavenTools/GridManager/WorkerTest.php
+++ b/tests/RavenTools/GridManager/WorkerTest.php
@@ -45,6 +45,28 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
     {
     }
 
+	public function testInitWorkItemCallbackArray() {
+
+		$callbacks = [
+			function() {},
+			function() {}
+		];
+
+		// test constructing w/ an array
+		$w = new Worker([
+			"work_item_callback" => $callbacks
+		]);
+
+		$this->assertSame($callbacks,$w->getWorkItemCallbacks());
+
+		// test adding subsequent callback
+		$cb = function() {};
+		$w->addWorkItemCallback($cb);
+		$callbacks[] = $cb;
+
+		$this->assertSame($callbacks,$w->getWorkItemCallbacks());
+	}
+
 	public function testRun() 
 	{
 		$response = $this->object->run();


### PR DESCRIPTION
PR #11 introduced a bug when constructing a `Worker` with multiple work item callbacks,  this fixes the issue and adds a unit test.
