### PR TITLE
Bug: fix single item batch, always count items

### DIFF
--- a/src/RavenTools/GridManager/Output.php
+++ b/src/RavenTools/GridManager/Output.php
@@ -130,8 +130,9 @@ class Output {
 
 				if(count($write_data_buffer) < $this->write_data_batch_size) {
 					$write_data_buffer[] = $output_item;
-				} else {
+				}
 
+				if(count($write_data_buffer) >= $this->write_data_batch_size) {
 					$this->writeData($write_data_buffer,$response);
 
 					// TODO sane failed write_data retries.
@@ -154,10 +155,11 @@ class Output {
 	 */
 	protected function writeData(Array $buffer,&$response) {
 
+		$response['items'] += count($buffer);
+
 		$cb = $this->write_data_callback;
 		if(call_user_func($cb,$buffer) === true) {
 			$response['success']++;
-			$response['items'] += count($buffer);
 			return true;
 		} else {
 			$response['failure']++;

--- a/tests/RavenTools/GridManager/OutputTest.php
+++ b/tests/RavenTools/GridManager/OutputTest.php
@@ -167,6 +167,6 @@ class OutputTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey("failure",$response);
         $this->assertEquals(1,$response['failure']);
         $this->assertArrayHasKey("items",$response);
-        $this->assertEquals(0,$response['items']);
+        $this->assertEquals(4,$response['items']);
 	}
 }


### PR DESCRIPTION
When setting a write data batch size of 1, every other item was skipped.  Broke the write into its own conditional so it could always run if necessary.  Also, moved the items counter outside of the conditional so that items are counted for both success and error conditions.
