### PR TITLE
Output Stage: expect not false instead of true

### DIFF
--- a/src/RavenTools/GridManager/Output.php
+++ b/src/RavenTools/GridManager/Output.php
@@ -158,7 +158,7 @@ class Output {
 		$response['items'] += count($buffer);
 
 		$cb = $this->write_data_callback;
-		if(call_user_func($cb,$buffer) === true) {
+		if(call_user_func($cb,$buffer) !== false) {
 			$response['success']++;
 			return true;
 		} else {


### PR DESCRIPTION
Having the Output write data callback only return true or false makes it difficult to test.  Expecting false on failure, but other values on success allows us to return a count from the callback and make testing those callbacks easier.
