### PR TITLE
SQS: add create method

### DIFF
--- a/src/RavenTools/GridManager/QueueInterface.php
+++ b/src/RavenTools/GridManager/QueueInterface.php
@@ -23,4 +23,9 @@ interface QueueInterface {
 	 * return the current queue length
 	 */
 	public function length();
+
+	/**
+	 * creates the queue
+	 */
+	public function create();
 }

--- a/src/RavenTools/GridManager/SQSQueue.php
+++ b/src/RavenTools/GridManager/SQSQueue.php
@@ -8,6 +8,7 @@ class SQSQueue implements \RavenTools\GridManager\QueueInterface {
 	protected $queue_name = null;
 	protected $queue_url = null;
 	protected $timeout = 1;
+	protected $visibility_timeout = 300;
 
 	public function __construct(Array $params) {
 		$this->validateAndSetParams($params);
@@ -36,6 +37,18 @@ class SQSQueue implements \RavenTools\GridManager\QueueInterface {
 		if(array_key_exists("timeout",$params)) {
 			$this->timeout = $params['timeout'];
 		}
+
+		if(array_key_exists("visibility_timeout",$params)) {
+			$this->visibility_timeout = $params['visibility_timeout'];
+		}
+	}
+
+	public function setSQSClient($client) {
+		$this->sqs_client = $client;
+	}
+
+	public function getSQSClient() {
+		return $this->sqs_client;
 	}
 
 	/**
@@ -112,6 +125,25 @@ class SQSQueue implements \RavenTools\GridManager\QueueInterface {
 			return false;
 		}
 		return $response->getPath("Attributes/ApproximateNumberOfMessages");
+	}
+
+	/**
+	 * creates the queue
+	 */
+	public function create() {
+
+		try {
+			$this->sqs_client->createQueue([
+				'QueueName' => $this->queue_name,
+				'Attributes' => [
+					'VisibilityTimeout' => $this->visibility_timeout
+				]
+			]);
+		} catch(\Exception $e) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/RavenTools/GridManager/SQSQueueTest.php
+++ b/tests/RavenTools/GridManager/SQSQueueTest.php
@@ -129,4 +129,25 @@ class SQSQueueTest extends PHPUnit_Framework_TestCase
 		$response = $this->object->length();
 		$this->assertFalse($response);
 	}
+
+	/**
+	 * @covers SQSQueue::create
+	 */
+	public function testCreate() {
+
+		$sqs_client_mock = m::mock("SQSClient");
+		$sqs_client_mock 
+			->shouldReceive("createQueue");
+		$this->object->setSQSClient($sqs_client_mock);
+
+		$this->assertTrue($this->object->create());
+
+		$sqs_client_mock = m::mock("SQSClient");
+		$sqs_client_mock 
+			->shouldReceive("createQueue")
+			->andThrow(new \Exception("some aws exception"));
+		$this->object->setSQSClient($sqs_client_mock);
+
+		$this->assertFalse($this->object->create());
+	}
 }


### PR DESCRIPTION
Adds `create()` method to `SQSQueue` and `QueueInterface`, as well as a supporting unit test case.
