### PR TITLE
Worker: replace /proc/pid stat with start_ts

### DIFF
--- a/src/RavenTools/GridManager/Worker.php
+++ b/src/RavenTools/GridManager/Worker.php
@@ -198,6 +198,7 @@ class Worker {
 				}
 
 				if(++$this->num_processed >= $this->num_to_process) {
+					Log::info(sprintf("Restart after processing %s jobs",$this->num_processed));
 					$this->running = false;
 				} elseif($response['failure'] > $response['success']) {
 					sleep(1);
@@ -207,6 +208,7 @@ class Worker {
 			} else {
 
 				if(!is_null($this->shutdown_timeout) && $this->last_item_ts < (time() - $this->shutdown_timeout)) {
+					Log::info("Restart due to timeout");
 					$this->running = false;
 				}
 
@@ -214,14 +216,14 @@ class Worker {
 			}
 
 			if($this->shouldShutdown()) {
-				Log::info("shutdown requested");
+				Log::info("Shutdown requested");
 
 				if(is_callable($this->shutdown_callback)) {
 					Log::info("calling shutdown function");
 					call_user_func($this->shutdown_callback);
 				}
 			} elseif($this->shouldRestart()) {
-				Log::info("restart requested");
+				Log::info("Restart requested");
 				sleep(2); // prevent flapping
 				$this->running = false;
 			}

--- a/src/RavenTools/GridManager/Worker.php
+++ b/src/RavenTools/GridManager/Worker.php
@@ -247,18 +247,14 @@ class Worker {
 	 */
 	private function shouldExit($type) {
 		$haltfile = "/tmp/halt_workers";
-		$procfile = sprintf('/proc/%s',getmypid());
-		clearstatcache($procfile);
-		$start_time = stat($procfile)[9];
 
 		if(!is_file($haltfile)) {
 			return false;
 		}
 
 		clearstatcache($haltfile);
-		clearstatcache($procfile);
 		$halt_time = stat($haltfile)[9];
-		if($halt_time < $start_time) {
+		if($halt_time < $this->start_ts) {
 			return false;
 		}
 


### PR DESCRIPTION
Using a stat of `/proc/[pid]` was returning an incorrect timestamp in some circumstances.  This switches to using a private `start_ts` variable and adds some additional logging.